### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ In `lms.env.json`  file:
 
 - `"AUTH0_DOMAIN": "your.auth0.domain"` to the list of `FEATURES`.
 
+- `"ENABLE_THIRD_PARTY_AUTH": true` in the list of `FEATURES`.
+
 
 ## Migrate DB
 


### PR DESCRIPTION
The Auth0 Third Party provider won't be shown in Django admin unless ENABLE_THIRD_PARTY_AUTH is set to true.