### PR TITLE
Fix get_user_id method and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,21 @@ In `lms.env.json`  file:
 ## Django's management page, set for third-party authentication backend.
 
 Open URL `/admin` on Browser.
+
 Go to `Home › Third_Party_Auth › Provider Configuration (OAuth)` and click Add Provider Configuration
+
 Check off `Enabled` checkbox
+
 Add a name in the `Name` input, ie. Auth0
+
 Check off `Skip Email Verification` checkbox
+
 Choose `Backend Name`: oa2-auth0
+
 Input your `Client ID` and `Client Secret`
-In `Other Settings`, paste this: ```{"SCOPE": ["email openid profile"]}``` this makes sure we can fetch the whole profile from Auth0 and your email address and other info will be properly populated in registration form
+
+In `Other Settings`, paste this: ```{"SCOPE": ["email openid profile"]}``` this makes sure we can fetch the whole profile from 
+Auth0 and your email address and other info will be properly populated in registration form
 
  
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ In `lms.env.json`  file:
 ## Django's management page, set for third-party authentication backend.
 
 Open URL `/admin` on Browser.
- 
+Go to `Home › Third_Party_Auth › Provider Configuration (OAuth)` and click Add Provider Configuration
+Check off `Enabled` checkbox
+Add a name in the `Name` input, ie. Auth0
+Check off `Skip Email Verification` checkbox
+Choose `Backend Name`: oa2-auth0
+Input your `Client ID` and `Client Secret`
+In `Other Settings`, paste this: ```{"SCOPE": ["email openid profile"]}``` this makes sure we can fetch the whole profile from Auth0 and your email address and other info will be properly populated in registration form
+
  
 

--- a/openedx_auth0/auth0.py
+++ b/openedx_auth0/auth0.py
@@ -60,4 +60,4 @@ class Auth0OAuth2(BaseOAuth2):
 
     def get_user_id(self, details, response):
         """ Get the permanent ID for this user from Auth0. """
-        return response.get('user_id', u'')
+        return response.get('sub', u'')


### PR DESCRIPTION
Method get_user_id was fetching for "user_id" field which does not exist in Auth0 profile right now. Field "sub" contains the Auth0 user ID but only if edX auth provider is correctly set up.
That is why I added edX Third Party configuration with the most important part being "Other settings" which sets Open ID claims so we can pull full user profile from Auth0.